### PR TITLE
Add jumpstart HTML file

### DIFF
--- a/jumpstart.html
+++ b/jumpstart.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ČeSFuR TV Jumpstarter</title>
+</head>
+<body>
+    <h1>ČeSFuR TV Jumpstarter</h1>
+    <p>Waiting for internet connection to <code id="config"></code> <span id="dots"></span></p>
+    <script>
+        /* Cesfur jumpstart script
+         *
+         * Takes a GET parameter from the URL called "config", tries to fetch
+         * the contents of this URL and on success, redirects to whatever URL
+         * it found in the contents.
+         *
+         * This is meant as a script that can be auto started by the operating
+         * system in a browser that waits until internet connection is available
+         * before redirecting - thus, the provided URL should only be available
+         * as soon as the target is.
+         */
+
+        // DECLARATIONS
+
+        // http://stackoverflow.com/a/11582513
+        function getURLParameter(name) {
+            return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [null, ''])[1].replace(/\+/g, '%20')) || null;
+        }
+
+        // https://www.kirupa.com/html5/check_if_internet_connection_exists_in_javascript.htm
+        function doesConnectionExist(url, onSuccess, onFailure) {
+            var xhr = new XMLHttpRequest();
+            var randomNum = Math.round(Math.random() * 10000);
+
+            console.debug('Probing', url);
+            xhr.open('GET', url + "?rand=" + randomNum, true);
+            xhr.send();
+
+            xhr.addEventListener("readystatechange", processRequest, false);
+
+            function processRequest(e) {
+              console.debug('ReadyState', xhr.readyState);
+              if (xhr.readyState == 4) {
+                console.debug('status', xhr.status);
+                if (xhr.status >= 200 && xhr.status < 304) {
+                  onSuccess(xhr.responseText);
+                } else {
+                  onFailure();
+                }
+              }
+            }
+        };
+
+        function start(destination) {
+            window.location = destination;
+        };
+
+        function notAvailable() {
+            dots.innerHTML += '.';
+            setTimeout(checkConn, 500);
+        };
+
+        function checkConn() {
+            doesConnectionExist(jumpstart_url, start, notAvailable);
+        };
+
+        // MAIN
+        var jumpstart_url = getURLParameter('config');
+        var dots = document.getElementById('dots');
+        var config = document.getElementById('config');
+
+        if (!jumpstart_url) {
+            alert('You have to pass a config URL via "?config=<url>" URL parameter!');
+        } else {
+            config.innerHTML = jumpstart_url;
+
+            // act as if not available for starting the process
+            notAvailable();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
The Javascript in this HTML file parses the `config` GET parameter from URL and tries to fetch its contents. As soon as it is availble, it redirects the browser to the URL found.

This is for solving two problems:

* No internet connection when the TV host starts (when calling the TV URL, the browser would just raise an error and "die")
* No access to the TV host: The contents of the config URL can be modified more easily via a web frontend or such.

See a screencast of how it works. Please notice that the file runs on a dev server on localhost, but that was just me not paying attention when doing the screencast. It can be called as a file with `firefox "/local/path/to/jumpstart.html?conf=CONFIG_URL"` as well.

What can be seen:

* Script started without config parameter (error message)
* Script gets config parameter, URL is not available
* Config URL gets available by renaming it on the left
* Script redirects to cesfur.org
* On the left, it's shown what `https://cesfur.org` in indeed the content of the file.

Please note that this may be a file, but a web server might return this string from a database as well.

![cast_cesfur_jumpstart](https://cloud.githubusercontent.com/assets/1580789/24520799/0a4af730-158a-11e7-8242-8ff98cdd9963.gif)


